### PR TITLE
Add 'unpkg' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.1",
   "description": "An implementation and polyfill of the Resize Observer draft.",
   "main": "lib/ResizeObserver.js",
+  "unpkg": "dist/resize-observer.min.js",
   "typings": "lib/ResizeObserver.d.ts",
   "scripts": {
     "browserify:dev": "browserify lib/index.js -o dist/resize-observer.js",


### PR DESCRIPTION
Adding a `unpkg` field in `package.json` so you can load it in a script tag without specifying the dist file.
`https://unpkg.com/resize-observer` will now point to `dist/resize-observer.min.js`.