### PR TITLE
Fix memory & cpu leak after disconnect()

### DIFF
--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -52,6 +52,12 @@ class ResizeObserver {
     public disconnect() {
         this.$$observationTargets = [];
         this.$$activeTargets = [];
+        const index = resizeObservers.indexOf(this);
+        if (index < 0) {
+            return;
+        }
+        resizeObservers.splice(index, 1);
+        checkStopLoop();
     }
 }
 


### PR DESCRIPTION
ResizeObserver instances are not eligible for garbage collection since the top level resizeObservers still has a reference to them.
As a result whatever was referenced by the callback provided during instantiation, is also not garbage collected.