### PR TITLE
Fix: Enable reuse of ResizeObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 All minor versions less than 1.0.0 are breaking changes.
 
+## [UNRELEASED] - 2021-05-24
+### Fixed
+- Fix: Enable reuse of ResizeObserver (#96)
+
 ## [1.0.1] - 2021-05-24
 ### Fixed
 - Fix memory & cpu leak after `disconnect()` (#93; [thgreasi](https://github.com/thgreasi))
@@ -14,9 +18,13 @@ All minor versions less than 1.0.0 are breaking changes.
 ## [1.0.0] - 2018-11-28
 ### Added
 - Added `unpkg` field in `package.json`.
-  You can now load `dist/resize-observer.min.js` via `<script src="https://unpkg.com/resize-observer"></script>`. (#14) Thanks @renaatdemuynck!
+  You can now load `dist/resize-observer.min.js` via `<script src="https://unpkg.com/resize-observer"></script>`. (#14; [renaatdemuynck](https://github.com/renaatdemuynck))
 
 ### Changed
+- Include `src/` files in the npm package (#12)
+- `resize-observer` is now a [ponyfill](https://ponyfill.com)
+- Rewritten in TypeScript
+- Type declaration files are now generated
 - Migrate from Travis to CircleCI for PR tests (#13)
 - Removed defective coverage badge (f65192b)
 
@@ -67,6 +75,7 @@ All minor versions less than 1.0.0 are breaking changes.
 - license
 - npm package
 
+[UNRELEASED]: https://github.com/pelotoncycle/resize-observer/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/pelotoncycle/resize-observer/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/pelotoncycle/resize-observer/compare/v1.0.0-alpha.1...v1.0.0
 [1.0.0-alpha.1]: https://github.com/pelotoncycle/resize-observer/compare/v1.0.0-alpha.0...v1.0.0-alpha.1

--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -20,7 +20,6 @@ class ResizeObserver {
             throw TypeError(message);
         }
         this.$$callback = callback;
-        resizeObservers.push(this);
     }
 
     public observe(target: Element) {
@@ -33,7 +32,7 @@ class ResizeObserver {
             return;
         }
         this.$$observationTargets.push(new ResizeObservation(target));
-        startLoop();
+        registerResizeObserver(this);
     }
 
     public unobserve(target: Element) {
@@ -46,16 +45,29 @@ class ResizeObserver {
             return;
         }
         this.$$observationTargets.splice(index, 1);
-        checkStopLoop();
+        if (this.$$observationTargets.length === 0) {
+            deregisterResizeObserver(this);
+        }
     }
 
     public disconnect() {
         this.$$observationTargets = [];
         this.$$activeTargets = [];
-        const index = resizeObservers.indexOf(this);
-        if (index < 0) {
-            return;
-        }
+        deregisterResizeObserver(this);
+    }
+}
+
+function registerResizeObserver(resizeObserver: ResizeObserver) {
+    const index = resizeObservers.indexOf(resizeObserver);
+    if (index < 0) {
+        resizeObservers.push(resizeObserver);
+        startLoop();
+    }
+}
+
+function deregisterResizeObserver(resizeObserver: ResizeObserver) {
+    const index = resizeObservers.indexOf(resizeObserver);
+    if (index >= 0) {
         resizeObservers.splice(index, 1);
         checkStopLoop();
     }

--- a/test/resize-observer.test.js
+++ b/test/resize-observer.test.js
@@ -205,6 +205,41 @@ describe('ResizeObserver', () => {
             });
         });
 
+        describe('after last element unobserved', () => {
+            beforeEach(() => {
+                resizeObserver.unobserve(element);
+            });
+
+            it('calls cancelAnimationFrame once', () => {
+                expect(cancelAnimationFrameSpy.callCount).to.equal(1);
+            });
+
+            it('no longer dispatches when the element resizes', () => {
+                elementWidth = '10px';
+                elementHeight = '10px';
+
+                mockGcs.reset();
+                mockRaf.step();
+
+                expect(callback.callCount).to.equal(0);
+                expect(mockGcs.callCount).to.equal(0);
+            });
+
+            it('allows further elements to be observed', () => {
+                resizeObserver.observe(element);
+
+                elementWidth = '10px';
+                elementHeight = '10px';
+
+                mockGcs.reset();
+                mockRaf.step();
+
+                expect(callback.callCount).to.equal(1);
+                expect(mockGcs.callCount).to.equal(3,
+                    'expect getComputedStyle call count to be 3 (1x ResizeObserverEntry, 2x gather active obs.)');
+            });
+        });
+
         describe('after disconnect', () => {
             beforeEach(() => {
                 resizeObserver.disconnect();


### PR DESCRIPTION
#93 introduced an error where once `disconnect()` is called on a ResizeObserver, that ResizeObserver can no longer be used to track further elements. This does not appear to be intended behavior [in the spec](https://drafts.csswg.org/resize-observer/#dom-resizeobserver-disconnect).

This PR enables re-use of the ResizeObserver.

It also deregisters the ResizeObserver when the last element is unobserved in addition to when the ResizeObserver has `disconnect()` called on it.