### PR TITLE
fix: allow observing elements created in different window context

### DIFF
--- a/src/ResizeObserver.ts
+++ b/src/ResizeObserver.ts
@@ -82,13 +82,11 @@ function callbackGuard(callback: ResizeObserverCallback) {
     }
 }
 
-function targetGuard(functionName: string, target: Element) {
+function targetGuard(functionName: string, target: Element | null | undefined) {
     if (typeof(target) === 'undefined') {
         return `Failed to execute '${functionName}' on 'ResizeObserver': 1 argument required, but only 0 present.`;
     }
-    if (!(target.ownerDocument
-            && target.ownerDocument.defaultView
-            && target instanceof (target.ownerDocument.defaultView as any).Element)) {
+    if (!(target && target.nodeType === (window as any).Node.ELEMENT_NODE)) {
         return `Failed to execute '${functionName}' on 'ResizeObserver': parameter 1 is not of type 'Element'.`;
     }
 }


### PR DESCRIPTION
Per conversation here: https://github.com/pelotoncycle/resize-observer/issues/98#issuecomment-969156160

#99 didn't go far enough in fixing the issue presented in #98.

Though #99 does allow observing elements that exist in a different iframe, those elements must be attached to a document that is part of the same `window` context that the elements were created in.

It is possible, though, for an Element to be created in one frame/window and then attach it to a document in a different frame/window. In these cases, `target.ownerDocument` is updated to be the document that the element is attached to rather than the document that the element was originally created in. This makes it much more difficult to find out if it is an `Element`, since we can no longer assume that `target.ownerDocument.defaultView.Element` is the same `Element` class that the target was instantiated with.

We could technically loop through `window.frames` (or, `window` itself), but that gets to be a bit involved and also has both performance and reliability implications. For instance, an error is thrown if we try to access `window.frames[0].Element`, if `window.frames[0]` is a cross-origin frame. I can't be certain that we'd catch all the possible errors there, so instead we'll just go with checking if `target.nodeType === Node.ELEMENT_NODE` and call it a day.